### PR TITLE
refactor: remove redundant imports

### DIFF
--- a/gymapp/views.py
+++ b/gymapp/views.py
@@ -7,11 +7,8 @@ from django.contrib import messages
 
 from .forms import MemberForm, MemberInfoForm
 from .models import Member, Payment, Ejercicio, Rutina, DetalleRutina, ComentarioRutina
-from .models import Rutina, Member
 
 from django.utils import timezone
-
-from django.contrib import messages
 
 
 


### PR DESCRIPTION
## Summary
- remove duplicate `messages` import and redundant models import in `views`

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68ac7bc43ff48323a8707b93e10ed506