### PR TITLE
Preserve warm-up exercises when duplicating routines

### DIFF
--- a/gymapp/tests.py
+++ b/gymapp/tests.py
@@ -1,0 +1,40 @@
+from django.test import TestCase
+from django.urls import reverse
+
+from .models import Member, Rutina, DetalleRutina, Ejercicio
+
+
+class RutinaClienteDuplicationTest(TestCase):
+    def test_duplica_calentamiento(self):
+        """La duplicación de rutinas preserva los ejercicios de calentamiento"""
+
+        member = Member.objects.create(dni="1", nombre_apellido="Test")
+        ejercicio = Ejercicio.objects.create(nombre="Jumping Jacks")
+
+        rutina = Rutina.objects.create(member=member, estructura="hipertrofia")
+        DetalleRutina.objects.create(
+            rutina=rutina,
+            categoria="Movilidad",
+            ejercicio=ejercicio,
+            repeticiones="10",
+            es_calentamiento=True,
+        )
+        DetalleRutina.objects.create(
+            rutina=rutina,
+            categoria="Fuerza",
+            ejercicio=ejercicio,
+            series="3",
+            repeticiones="12",
+            es_calentamiento=False,
+        )
+
+        self.client.post(reverse("rutina_cliente", args=[member.id]))
+
+        self.assertEqual(member.rutinas.count(), 2)
+        nueva = member.rutinas.order_by("-fecha_creacion").first()
+        self.assertEqual(nueva.detalles.count(), 2)
+
+        calentamientos = nueva.detalles.filter(es_calentamiento=True)
+        self.assertEqual(calentamientos.count(), 1)
+        self.assertEqual(calentamientos.first().repeticiones, "10")
+

--- a/gymapp/views.py
+++ b/gymapp/views.py
@@ -225,6 +225,7 @@ def rutina_cliente(request, member_id):
                     rir=d.rir,
                     sensaciones=d.sensaciones,
                     notas=d.notas,
+                    es_calentamiento=d.es_calentamiento,
                 )
             if hasattr(ultima, "comentario"):
                 ComentarioRutina.objects.create(rutina=nueva, texto=ultima.comentario.texto)


### PR DESCRIPTION
## Summary
- Copy `es_calentamiento` flag when duplicating routine details to keep warm-up exercises
- Add regression test ensuring duplicated routines retain warm-up entries

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68ac7bcdd41c832381c040a0c7f664ab