### PR TITLE
Centrar tabla de rutinas y mejorar estilos

### DIFF
--- a/gymapp/templates/gymapp/mis_rutinas.html
+++ b/gymapp/templates/gymapp/mis_rutinas.html
@@ -2,7 +2,7 @@
 
 {% block content %}
 <div class="container mt-4 rutina-form">
-    <h3>Rutinas de {{ member.nombre_apellido }}</h3>
+    <h3 class="text-center">Rutinas de {{ member.nombre_apellido }}</h3>
     <hr>
 
     {% for rutina in rutinas %}
@@ -11,38 +11,40 @@
                 {{ rutina.get_estructura_display }} - {{ rutina.fecha_creacion|date:"d/m/Y H:i" }}
             </div>
             <div class="card-body">
-                <table class="table table-bordered text-center align-middle bg-white">
-                    <thead class="table-dark">
-                        <tr>
-                            <th>Categoría</th>
-                            <th>Ejercicio</th>
-                            <th>Series</th>
-                            <th>Reps</th>
-                            <th>Peso</th>
-                            <th>Descanso</th>
-                            <th>RIR</th>
-                            <th>Sensaciones</th>
-                            <th>Notas</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {% for d in rutina.detalles.all %}
-                        <tr>
-                            <td>{{ d.categoria }}</td>
-                            <td>{{ d.ejercicio.nombre }}</td>
-                            <td>{{ d.series }}</td>
-                            <td>{{ d.repeticiones }}</td>
-                            <td>{{ d.peso }}</td>
-                            <td>{{ d.descanso }}</td>
-                            <td>{{ d.rir }}</td>
-                            <td>{{ d.sensaciones }}</td>
-                            <td>{{ d.notas }}</td>
-                        </tr>
-                        {% empty %}
-                        <tr><td colspan="9" class="text-muted">Sin ejercicios</td></tr>
-                        {% endfor %}
-                    </tbody>
-                </table>
+                <div class="table-responsive">
+                    <table class="table table-bordered text-center align-middle">
+                        <thead class="table-dark">
+                            <tr>
+                                <th>Categoría</th>
+                                <th>Ejercicio</th>
+                                <th>Series</th>
+                                <th>Reps</th>
+                                <th>Peso</th>
+                                <th>Descanso</th>
+                                <th>RIR</th>
+                                <th>Sensaciones</th>
+                                <th>Notas</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for d in rutina.detalles.all %}
+                            <tr>
+                                <td>{{ d.categoria }}</td>
+                                <td>{{ d.ejercicio.nombre }}</td>
+                                <td>{{ d.series }}</td>
+                                <td>{{ d.repeticiones }}</td>
+                                <td>{{ d.peso }}</td>
+                                <td>{{ d.descanso }}</td>
+                                <td>{{ d.rir }}</td>
+                                <td>{{ d.sensaciones }}</td>
+                                <td>{{ d.notas }}</td>
+                            </tr>
+                            {% empty %}
+                            <tr><td colspan="9" class="text-muted">Sin ejercicios</td></tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
 
                 {% if rutina.comentario %}
                 <div class="mt-2">

--- a/static/css/rutinas.css
+++ b/static/css/rutinas.css
@@ -3,6 +3,14 @@
    Scope: .editar-rutinas
    ====================================================== */
 
+/* Estilos generales para las vistas de rutinas */
+.rutina-form {
+  max-width: 900px;
+  margin: auto;
+  padding: 1rem;
+  font-size: 0.95rem;
+}
+
 /* Paleta base (claro elegante) */
 .editar-rutinas {
   --bg: #ffffff;


### PR DESCRIPTION
## Summary
- Center routine heading and wrap routine table in a responsive container
- Add `.rutina-form` CSS with width limit, spacing and font adjustments

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68ac81ac66408323a74dc3d38aab115e