### PR TITLE
Center edit routine view with consistent styles

### DIFF
--- a/gymapp/templates/gymapp/editar_rutina.html
+++ b/gymapp/templates/gymapp/editar_rutina.html
@@ -3,8 +3,8 @@
 {% block title %}Editar Rutina{% endblock %}
 
 {% block content %}
-<div class="container my-4 rutina-form editar-rutinas" id="contenedor-calor">
-  <h2 class="mb-3">Editar Rutina</h2>
+<div class="container my-4 mx-auto rutina-form editar-rutinas" id="contenedor-calor" style="max-width:1000px;">
+  <h2 class="mb-3 text-center">Editar Rutina</h2>
 
   <form id="rutinaForm" method="post" action="">
     {% csrf_token %}

--- a/static/css/rutinas.css
+++ b/static/css/rutinas.css
@@ -15,11 +15,12 @@
   --accent: #2563eb;
   --accent-focus: rgba(37,99,235,.15);
   --danger: #dc2626;
-  --radius: 12px;
+  --radius: 1.5rem;
   --shadow: 0 6px 20px rgba(0,0,0,.08);
   --input-h: 40px;
   font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial;
   color: var(--text);
+  font-size: 1rem;
 }
 
 /* -------- Card look -------- */
@@ -62,7 +63,7 @@
   z-index: 2;
 }
 .editar-rutinas .table tbody td {
-  padding: 10px 12px;
+  padding: 0.75rem 1rem;
   border-bottom: 1px solid var(--border);
   vertical-align: middle;
 }
@@ -113,7 +114,7 @@
 
 /* -------- Botones -------- */
 .editar-rutinas .btn {
-  border-radius: 8px;
+  border-radius: 2rem;
   font-size: .9rem;
   padding: 6px 14px;
   transition: background .2s, transform .05s;
@@ -164,5 +165,10 @@
   background-color: #ffffff !important;  /* se diferencia en blanco */
   border-color: var(--accent) !important;
   box-shadow: 0 0 0 3px var(--accent-focus) !important;
+}
+
+/* -------- Spacing helpers -------- */
+.editar-rutinas .card-body {
+  padding: 1.5rem;
 }
 


### PR DESCRIPTION
## Summary
- Center edit routine form with `mx-auto`, width cap and heading alignment
- Harmonize edit routine typography, spacing, and radii for consistency

## Testing
- `python manage.py test`
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_68ac81c84a908323a0fcd0128c25bef1