### PR TITLE
style: center edit routine heading and layout

### DIFF
--- a/gymapp/templates/gymapp/editar_rutina.html
+++ b/gymapp/templates/gymapp/editar_rutina.html
@@ -3,8 +3,8 @@
 {% block title %}Editar Rutina{% endblock %}
 
 {% block content %}
-<div class="container my-4 rutina-form editar-rutinas" id="contenedor-calor">
-  <h2 class="mb-3">Editar Rutina</h2>
+<div class="container my-4 mx-auto rutina-form editar-rutinas" id="contenedor-calor" style="max-width:1000px;">
+  <h2 class="mb-3 text-center">Editar Rutina</h2>
 
   <form id="rutinaForm" method="post" action="">
     {% csrf_token %}


### PR DESCRIPTION
## Summary
- add max-width container and center heading in edit routine template
- merge latest main

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68ac84aa4da4832382bced07d02ef910