### PR TITLE
Permite scroll horizontal en tablas de edición de rutinas

### DIFF
--- a/static/css/rutinas.css
+++ b/static/css/rutinas.css
@@ -57,7 +57,8 @@
   background: var(--bg);
   border: 1px solid var(--border);
   border-radius: var(--radius);
-  overflow: hidden;
+  overflow-x: auto;
+  overflow-y: visible;
 }
 .editar-rutinas .table thead th {
   background: var(--head-bg);


### PR DESCRIPTION
## Summary
- Ajusta estilos de las tablas en la pantalla de edición de rutinas para permitir scroll horizontal
- Se confirmó que los contenedores `.table-responsive` envuelven las tablas correspondientes

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac88e119fc832387ad7729c0e37e2f