### PR TITLE
Ajusta fondo de elementos en editor de rutinas

### DIFF
--- a/static/css/rutinas.css
+++ b/static/css/rutinas.css
@@ -33,6 +33,7 @@
 
 /* -------- Card look -------- */
 .editar-rutinas .card {
+  background: var(--bg);
   border: 1px solid var(--border);
   border-radius: var(--radius);
   box-shadow: var(--shadow);
@@ -59,6 +60,11 @@
   border-radius: var(--radius);
   overflow: hidden;
 }
+.editar-rutinas .table th,
+.editar-rutinas .table td {
+  background: var(--bg);
+}
+
 .editar-rutinas .table thead th {
   background: var(--head-bg);
   color: var(--head-text);


### PR DESCRIPTION
## Summary
- Añade fondo base a las tarjetas del editor de rutinas
- Asegura que tablas y celdas usen el color de fondo de la paleta

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68ac88eaf01883239a96ebf9735a936e