### PR TITLE
Adjust card overflow and dropdown parent in routine editor

### DIFF
--- a/gymapp/templates/gymapp/editar_rutina.html
+++ b/gymapp/templates/gymapp/editar_rutina.html
@@ -205,7 +205,7 @@ function initSelect2(scope){
       allowClear: true,
       minimumResultsForSearch: 0,
       width: '100%',
-      dropdownParent: $sel.closest('.card, form, body')
+      dropdownParent: $(document.body)
     });
   });
 }

--- a/static/css/rutinas.css
+++ b/static/css/rutinas.css
@@ -37,7 +37,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius);
   box-shadow: var(--shadow);
-  overflow: hidden;
+  overflow: visible;
 }
 
 /* -------- Encabezados -------- */


### PR DESCRIPTION
## Summary
- Allow routine editor card overflow to be visible
- Attach Select2 dropdown menus to the document body

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68ac8c1c8f90832384319b2554506000