### PR TITLE
Allow rutinas styles to override base form colors

### DIFF
--- a/gymapp/templates/gymapp/base.html
+++ b/gymapp/templates/gymapp/base.html
@@ -38,7 +38,7 @@
         }
 
         .card, .form-control {
-            background-color: rgba(255, 255, 255, 0.07) !important;
+            background-color: rgba(255, 255, 255, 0.07);
             color: #f8f9fa;
         }
 

--- a/static/css/rutinas.css
+++ b/static/css/rutinas.css
@@ -105,8 +105,8 @@
   border-color: var(--border) !important;
   border-radius: 8px;
   padding: 0 10px;
-  background-color: var(--bg) !important;
-  color: var(--text) !important;
+  background-color: var(--bg);
+  color: var(--text);
   font-size: .95rem;
   transition: border-color .15s, box-shadow .15s;
 }


### PR DESCRIPTION
## Summary
- Remove `!important` from base `.card` and `.form-control` so rutinas.css can style routine editor inputs
- Simplify rutinas.css inputs and selects by dropping unnecessary `!important`

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68ac8f29dec88323be7bf323c6589ff8