### PR TITLE
Add sticky column styling for routines table

### DIFF
--- a/static/css/rutinas.css
+++ b/static/css/rutinas.css
@@ -92,6 +92,15 @@
   background: var(--row-hover);
 }
 
+/* Columna fija a la izquierda */
+.editar-rutinas .sticky-col {
+  position: sticky;
+  left: 0;
+  background: var(--bg);
+  z-index: 3;
+  box-shadow: 2px 0 4px rgba(0,0,0,.05);
+}
+
 /* -------- Inputs y selects -------- */
 .editar-rutinas input[type="text"],
 .editar-rutinas input[type="number"],


### PR DESCRIPTION
## Summary
- add `.sticky-col` rule to keep first column fixed in routine tables
- ensure sticky column keeps table background and border

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac9410bdd88323b70dd729505a6667