### PR TITLE
Scope table styles to avoid affecting light theme views

### DIFF
--- a/gymapp/templates/gymapp/base.html
+++ b/gymapp/templates/gymapp/base.html
@@ -42,7 +42,7 @@
             color: #f8f9fa;
         }
 
-        .table {
+        body:not(.editar-rutinas) .table {
             background-color: #1e1e2a !important;
             border-collapse: separate;
             border-spacing: 0;
@@ -50,23 +50,23 @@
             font-size: 0.95rem;
         }
 
-        .table-striped tbody tr:nth-of-type(odd) {
+        body:not(.editar-rutinas) .table-striped tbody tr:nth-of-type(odd) {
             background-color: #2a2a3c !important;
         }
 
-        .table td,
-        .table th {
+        body:not(.editar-rutinas) .table td,
+        body:not(.editar-rutinas) .table th {
             color: #ffffff !important;
             font-weight: 600 !important;
             background-color: transparent !important;
             border-color: #444 !important;
         }
 
-        .table thead {
+        body:not(.editar-rutinas) .table thead {
             background-color: #2d2d45 !important;
         }
 
-        .table thead th {
+        body:not(.editar-rutinas) .table thead th {
             color: #f9f9f9 !important;
             font-weight: 700 !important;
             border-bottom: 2px solid #555 !important;


### PR DESCRIPTION
## Summary
- Restrict dark theme table styles to pages without the `editar-rutinas` body class

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68ac941219688323a34ea3ac558df4cf