### PR TITLE
Refine routine editor card styling

### DIFF
--- a/static/css/rutinas.css
+++ b/static/css/rutinas.css
@@ -14,17 +14,17 @@
 /* Paleta base (claro elegante) */
 .editar-rutinas {
   --bg: #ffffff;
-  --border: #e5e7eb;
+  --border: #ececec;
   --head-bg: #f3f4f6;
   --head-text: #111827;
   --text: #1f2937;
   --muted: #6b7280;
   --row-hover: #f9fafb;
-  --accent: #2563eb;
-  --accent-focus: rgba(37,99,235,.15);
+  --accent: #3B82F6;
+  --accent-focus: rgba(59,130,246,.15);
   --danger: #dc2626;
-  --radius: 1.5rem;
-  --shadow: 0 6px 20px rgba(0,0,0,.08);
+  --radius: 0.75rem;
+  --shadow: 0 2px 8px rgba(0,0,0,.05);
   --input-h: 40px;
   font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial;
   color: var(--text);
@@ -38,7 +38,7 @@
   border: 1px solid var(--border);
   border-color: var(--border) !important;
   border-radius: var(--radius);
-  box-shadow: var(--shadow);
+  box-shadow: 0 1px 3px rgba(0,0,0,0.04);
   overflow: visible;
 }
 


### PR DESCRIPTION
## Summary
- Soften routine editor visuals with lighter border, reduced radius and shadow, and calmer accent color
- Apply subtle box-shadow to cards for less visual weight

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68ac9e27d5688323abe0c7bd53b4f957