### PR TITLE
Support multiple routine tables

### DIFF
--- a/gymapp/templates/gymapp/mis_rutinas.html
+++ b/gymapp/templates/gymapp/mis_rutinas.html
@@ -17,7 +17,7 @@
             </div>
             <div class="card-body">
                 <div class="table-responsive">
-                    <div id="rutinasTable" class="tabulator--bootstrap5"></div>
+                    <div id="rutinasTable{{ forloop.counter }}" class="tabulator--bootstrap5"></div>
                 </div>
 
                 {% if rutina.comentario %}
@@ -33,20 +33,23 @@
 </div>
 
 <script>
-  const table = new Tabulator("#rutinasTable", {
-    data: {{ rutina_data|safe }},
-    layout: "fitDataFill",
-    columns: [
-      {title: "Categoría", field: "categoria"},
-      {title: "Ejercicio", field: "ejercicio"},
-      {title: "Series", field: "series", hozAlign: "center"},
-      {title: "Reps", field: "repeticiones", hozAlign: "center"},
-      {title: "Peso", field: "peso", hozAlign: "center"},
-      {title: "Descanso", field: "descanso"},
-      {title: "RIR", field: "rir", hozAlign: "center"},
-      {title: "Sensaciones", field: "sensaciones"},
-      {title: "Notas", field: "notas"}
-    ]
+  const rutinasData = {{ rutina_data|safe }};
+  Object.keys(rutinasData).forEach((id, index) => {
+    new Tabulator(`#rutinasTable${index + 1}`, {
+      data: rutinasData[id],
+      layout: "fitDataFill",
+      columns: [
+        {title: "Categoría", field: "categoria"},
+        {title: "Ejercicio", field: "ejercicio"},
+        {title: "Series", field: "series", hozAlign: "center"},
+        {title: "Reps", field: "repeticiones", hozAlign: "center"},
+        {title: "Peso", field: "peso", hozAlign: "center"},
+        {title: "Descanso", field: "descanso"},
+        {title: "RIR", field: "rir", hozAlign: "center"},
+        {title: "Sensaciones", field: "sensaciones"},
+        {title: "Notas", field: "notas"}
+      ]
+    });
   });
 </script>
 {% endblock %}

--- a/gymapp/views.py
+++ b/gymapp/views.py
@@ -346,12 +346,11 @@ def eliminar_rutina(request, rutina_id):
 
 def mis_rutinas(request, member_id):
     member = get_object_or_404(Member, pk=member_id)
-    rutinas = list(member.rutinas.order_by("-fecha_creacion")[:1])
+    rutinas = member.rutinas.order_by("-fecha_creacion")
 
-    rutina_data = []
-    if rutinas:
-        rutina = rutinas[0]
-        rutina_data = list(
+    rutina_data = {}
+    for rutina in rutinas:
+        data = list(
             rutina.detalles.all().values(
                 "categoria",
                 "series",
@@ -364,8 +363,9 @@ def mis_rutinas(request, member_id):
                 ejercicio=F("ejercicio__nombre"),
             )
         )
+        rutina_data[str(rutina.id)] = data
 
-        rutina_data = json.dumps(rutina_data)
+    rutina_data = json.dumps(rutina_data)
 
     return render(request, "gymapp/mis_rutinas.html", {
         "member": member,


### PR DESCRIPTION
## Summary
- render a Tabulator table for each routine dynamically
- serialize routine details per routine and initialize with JavaScript

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68adc423b10c8323853f5458817c1b7d