### PR TITLE
Refactor template styles into shared forms stylesheet

### DIFF
--- a/gymapp/templates/gymapp/add_member.html
+++ b/gymapp/templates/gymapp/add_member.html
@@ -2,9 +2,9 @@
 {% load widget_tweaks %}
 {% block title %}Agregar Socio{% endblock %}
 {% block content %}
-<div class="d-flex justify-content-center align-items-center" style="min-height: 90vh;">
-<div class="card shadow-lg rounded-4 p-4" style="width: 100%; max-width: 560px; border: none;">
-<h2 class="mb-4 text-center" style="letter-spacing:1px; font-weight:700;">Agregar nuevo socio</h2>
+<div class="d-flex justify-content-center align-items-center vh-90">
+<div class="card shadow-lg rounded-4 p-4 card-560 full-width card-no-border">
+<h2 class="mb-4 text-center title-spaced">Agregar nuevo socio</h2>
 <form autocomplete="off" method="post">
             {% csrf_token %}
             

--- a/gymapp/templates/gymapp/base.html
+++ b/gymapp/templates/gymapp/base.html
@@ -21,6 +21,7 @@
 
     {% block extra_head %}{% endblock %}
     <link rel="stylesheet" href="{% static 'css/base.css' %}">
+    <link rel="stylesheet" href="{% static 'css/forms.css' %}">
 </head>
 <body>
 

--- a/gymapp/templates/gymapp/confirm_delete.html
+++ b/gymapp/templates/gymapp/confirm_delete.html
@@ -1,7 +1,7 @@
 {% extends 'gymapp/base.html' %}
 {% block title %}Eliminar Socio{% endblock %}
 {% block content %}
-<div class="card shadow rounded p-4 mx-auto" style="max-width:600px;">
+<div class="card shadow rounded p-4 mx-auto card-600">
     <h3>¿Seguro que querés eliminar a <span class="text-danger">{{ member.nombre }} {{ member.apellido }}</span>?</h3>
     <form method="post" class="mt-3">
         {% csrf_token %}

--- a/gymapp/templates/gymapp/edit_member.html
+++ b/gymapp/templates/gymapp/edit_member.html
@@ -2,7 +2,7 @@
 {% block title %}Editar Socio{% endblock %}
 {% block content %}
 {% load widget_tweaks %}
-<div class="card shadow rounded p-4 mx-auto" style="max-width:600px;">
+<div class="card shadow rounded p-4 mx-auto card-600">
 <h2 class="mb-4">Editar socio</h2>
 <form method="post">
     {% csrf_token %}<button class="btn btn-primary" type="submit">Guardar cambios</button>

--- a/gymapp/templates/gymapp/editar_rutina.html
+++ b/gymapp/templates/gymapp/editar_rutina.html
@@ -3,7 +3,7 @@
 {% block title %}Editar Rutina{% endblock %}
 
 {% block content %}
-<div class="container my-4 mx-auto rutina-form editar-rutinas" id="contenedor-calor" style="max-width:1000px;">
+<div class="container my-4 mx-auto rutina-form editar-rutinas card-1000" id="contenedor-calor">
   <h2 class="mb-3 text-center">Editar Rutina</h2>
 
   <form id="rutinaForm" method="post" action="">

--- a/gymapp/templates/gymapp/historial_pagos.html
+++ b/gymapp/templates/gymapp/historial_pagos.html
@@ -7,7 +7,7 @@
   <div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-4 g-3">
     {% for item in historial %}
       <div class="col">
-        <div class="card h-100 shadow-sm" style="border:none;">
+        <div class="card h-100 shadow-sm card-no-border">
           <div class="card-body d-flex flex-column justify-content-between">
             <div class="d-flex align-items-center justify-content-between mb-2">
               <strong>{{ item.mes }}</strong>

--- a/gymapp/templates/gymapp/login_cliente.html
+++ b/gymapp/templates/gymapp/login_cliente.html
@@ -2,7 +2,7 @@
 {% block title %}Ingreso de socio{% endblock %}
 {% block content %}
 <div class="container py-5 d-flex justify-content-center">
-  <div class="card shadow-lg rounded-4 p-4" style="max-width:420px; width:100%; border:none;">
+  <div class="card shadow-lg rounded-4 p-4 card-420 full-width card-no-border">
     <h2 class="mb-3 text-center">Ingreso de socio</h2>
     <form method="post" autocomplete="off">
       {% csrf_token %}

--- a/static/css/forms.css
+++ b/static/css/forms.css
@@ -1,0 +1,35 @@
+/* Helper classes for form layouts and cards */
+
+.vh-90 {
+    min-height: 90vh;
+}
+
+.full-width {
+    width: 100%;
+}
+
+.card-no-border {
+    border: none;
+}
+
+.card-420 {
+    max-width: 420px;
+}
+
+.card-560 {
+    max-width: 560px;
+}
+
+.card-600 {
+    max-width: 600px;
+}
+
+.card-1000 {
+    max-width: 1000px;
+}
+
+.title-spaced {
+    letter-spacing: 1px;
+    font-weight: 700;
+}
+


### PR DESCRIPTION
## Summary
- add `forms.css` with reusable utilities for card widths, spacing and typography
- replace inline styles in member and routine templates with new CSS classes
- include `forms.css` in `base.html` so templates share consistent styling

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68ae35362c188323b74c672f9984c812