### PR TITLE
Style member search input via dedicated class

### DIFF
--- a/gymapp/templates/gymapp/member_list.html
+++ b/gymapp/templates/gymapp/member_list.html
@@ -9,7 +9,7 @@
 
     <!-- Barra de búsqueda -->
     <form method="get" class="mb-3">
-        <input type="text" name="q" value="{{ request.GET.q }}" class="form-control" placeholder="Buscar socio...">
+        <input type="text" name="q" value="{{ request.GET.q }}" class="form-control search-member" placeholder="Buscar socio...">
     </form>
 
     <table class="table table-striped table-hover align-middle">

--- a/static/css/socios.css
+++ b/static/css/socios.css
@@ -52,15 +52,3 @@
 .table a.btn:hover {
     transform: scale(1.05);
 }
-
-/* Input búsqueda lista de socios */
-.container form input.form-control {
-    background-color: #2c3e50 !important;  /* fondo gris oscuro */
-    color: #fff !important;               /* texto blanco */
-    border: 1px solid #444 !important;
-}
-
-/* Placeholder */
-.container form input.form-control::placeholder {
-    color: #ccc !important;
-}

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -50,8 +50,9 @@ body {
 }
 
 
-/* Estilo especial para el input de búsqueda de socio */
-form input[name="q"] {
+/* Estilo especial para el campo de búsqueda de socio */
+.search-member {
     color: #000;
     background-color: #fff;
+    border: 1px solid #ccc;
 }


### PR DESCRIPTION
## Summary
- Add reusable `.search-member` class for search input styling
- Apply `search-member` class on member list search field
- Drop redundant input styles from `socios.css`

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68ae354127f083239c32db8b71cf6143