### PR TITLE
Use shared font variable for consistent typography

### DIFF
--- a/static/css/base.css
+++ b/static/css/base.css
@@ -1,9 +1,13 @@
+:root {
+    --font-primary: 'Montserrat', sans-serif;
+}
+
 body {
     background: linear-gradient(rgba(0, 0, 0, 0.3), rgba(0, 0, 0, 0.3)), url('../img/buried_dark.png');
     background-size: cover;
     background-attachment: fixed;
     color: #f8f9fa;
-    font-family: 'Montserrat', sans-serif;
+    font-family: var(--font-primary);
 }
 
 .navbar {

--- a/static/css/rutinas.css
+++ b/static/css/rutinas.css
@@ -26,7 +26,7 @@
   --radius: 0.75rem;
   --shadow: 0 2px 8px rgba(0,0,0,.05);
   --input-h: 40px;
-  font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial;
+  font-family: var(--font-primary);
   color: var(--text);
   font-size: 1rem;
 }
@@ -261,7 +261,7 @@
 
 /* -------- Tabulator custom style -------- */
 #rutinasTable {
-  font-family: 'Montserrat', sans-serif;
+  font-family: var(--font-primary);
   color: #f8f9fa;
 }
 

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -30,7 +30,7 @@ textarea::placeholder {
 
 /* Aplica Montserrat a todo el sitio */
 body {
-    font-family: 'Montserrat', sans-serif;
+    font-family: var(--font-primary);
 }
 
 /* Seguimos con tus estilos originales */


### PR DESCRIPTION
## Summary
- centralize primary font declaration with CSS variable
- update page-specific styles to reference the shared font

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68ae34f9beb88323a309cf49e6fec9f8