### PR TITLE
Add global theme variables and dark/light toggle

### DIFF
--- a/gymapp/templates/gymapp/base.html
+++ b/gymapp/templates/gymapp/base.html
@@ -22,7 +22,7 @@
     {% block extra_head %}{% endblock %}
     <link rel="stylesheet" href="{% static 'css/base.css' %}">
 </head>
-<body>
+<body class="dark-mode">
 
 <!-- Fondo con onda decorativa -->
 <div class="wave-bg">
@@ -46,6 +46,9 @@
                 <i class="bi bi-file-earmark-excel-fill fs-5"></i>
                 Exportar Excel
             </a>
+            <button id="theme-toggle" class="btn btn-outline-light btn-lg rounded-pill d-flex align-items-center gap-1 shadow-sm ms-2" aria-label="Cambiar tema">
+                <i class="bi bi-sun"></i>
+            </button>
         </div>
     </div>
 </nav>
@@ -76,6 +79,8 @@
 <!-- Select2 JS -->
 <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+
+<script src="{% static 'js/theme-toggle.js' %}"></script>
 
 </body>
 </html>

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -1,31 +1,60 @@
+/* Global color variables */
+:root {
+    --bg-dark: #2e2e3e;
+    --bg-dark-alt: #34495e;
+    --bg-light: #ffffff;
+    --text-light: #f8f9fa;
+    --text-dark: #2c3e50;
+    --accent: #ffc107;
+    --border-dark: #444;
+    --border-muted: #999;
+    --hover-light: #f2f6fc;
+    --placeholder: #ccc;
+    --body-bg-dark: linear-gradient(rgba(0, 0, 0, 0.3), rgba(0, 0, 0, 0.3)), url('../img/buried_dark.png');
+    --body-bg-light: var(--bg-light);
+    --body-bg: var(--body-bg-dark);
+    --success: #2EA44F;
+    --success-hover: #2C974B;
+    --danger: #E5534B;
+    --danger-hover: #D0453C;
+    --focus-outline: #2563eb;
+}
+
 body {
-    background: linear-gradient(rgba(0, 0, 0, 0.3), rgba(0, 0, 0, 0.3)), url('../img/buried_dark.png');
+    background: var(--body-bg);
     background-size: cover;
     background-attachment: fixed;
-    color: #f8f9fa;
+    color: var(--text-light);
     font-family: 'Montserrat', sans-serif;
 }
 
+/* Light mode override */
+body.light-mode {
+    --body-bg: var(--body-bg-light);
+    color: var(--text-dark);
+}
+
+/* Navbar */
 .navbar {
-    background-color: #2e2e3e !important;
+    background-color: var(--bg-dark) !important;
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
 }
 
 .navbar-brand span {
-    color: #ffc107 !important;
+    color: var(--accent) !important;
 }
 
 .card,
 .form-control {
     background-color: rgba(255, 255, 255, 0.07);
-    color: #f8f9fa;
+    color: var(--text-light);
 }
 
 .btn-outline-success,
 .btn-outline-primary {
     background-color: rgba(255, 255, 255, 0.05);
-    border-color: #999;
-    color: #f8f9fa;
+    border-color: var(--border-muted);
+    color: var(--text-light);
 }
 
 .btn-outline-success:hover,

--- a/static/css/rutinas.css
+++ b/static/css/rutinas.css
@@ -13,16 +13,15 @@
 
 /* Paleta base (claro elegante) */
 .editar-rutinas {
-  --bg: #ffffff;
+  --bg: var(--bg-light);
   --border: #ececec;
-  --head-bg: #f3f4f6;
-  --head-text: #111827;
-  --text: #1f2937;
+  --head-bg: var(--hover-light);
+  --head-text: var(--text-dark);
+  --text: var(--text-dark);
   --muted: #6b7280;
-  --row-hover: #f9fafb;
-  --accent: #3B82F6;
-  --accent-focus: rgba(59,130,246,.15);
-  --danger: #dc2626;
+  --row-hover: var(--hover-light);
+  --accent: var(--accent);
+  --accent-focus: rgba(255,193,7,.15);
   --radius: 0.75rem;
   --shadow: 0 2px 8px rgba(0,0,0,.05);
   --input-h: 40px;
@@ -94,7 +93,7 @@
 .editar-rutinas .grid-row {
   padding: 0.75rem 1rem;
   background: transparent;
-  border-bottom: 1px solid #ececec;
+  border-bottom: 1px solid var(--border);
 }
 
 /* Columna fija a la izquierda */
@@ -104,7 +103,7 @@
   background: var(--bg);
   z-index: 3;
   box-shadow: none;
-  border-right: 1px solid #ececec;
+  border-right: 1px solid var(--border);
 }
 
 /* Responsividad: permitir reflujo en pantallas pequeñas */
@@ -130,7 +129,7 @@
   border-color: var(--border) !important;
   border-radius: 4px;
   padding: 0 10px;
-  background-color: #fafafa;
+  background-color: var(--bg-light);
   color: var(--text);
   font-size: .95rem;
   font-weight: 500;
@@ -153,7 +152,7 @@
   height: var(--input-h) !important;
   display: flex !important;
   align-items: center;
-  background-color: #fafafa !important;
+  background-color: var(--bg-light) !important;
   font-weight: 500 !important;
 }
 .editar-rutinas .select2-selection__rendered {
@@ -170,17 +169,17 @@
   padding: 6px 14px;
   transition: background .2s;
 }
-.editar-rutinas .btn-success { background: #2EA44F; border: none; }
-.editar-rutinas .btn-success:hover { background: #2C974B; }
-.editar-rutinas .btn-danger { background: #E5534B; border: none; }
-.editar-rutinas .btn-danger:hover { background: #D0453C; }
+.editar-rutinas .btn-success { background: var(--success); border: none; }
+.editar-rutinas .btn-success:hover { background: var(--success-hover); }
+.editar-rutinas .btn-danger { background: var(--danger); border: none; }
+.editar-rutinas .btn-danger:hover { background: var(--danger-hover); }
 .editar-rutinas .btn-outline-primary {
   border: 1px solid var(--accent);
   color: var(--accent);
 }
 .editar-rutinas .btn-outline-primary:hover {
   background: var(--accent);
-  color: #fff;
+  color: var(--text-light);
 }
 
 /* Botones de acción pequeños */
@@ -201,9 +200,9 @@
 /* Forzar estilo a los selects de Categoría */
 .editar-rutinas select[name^="categoria"],
 .editar-rutinas select[name^="cal_categoria"] {
-  background-color: #e5e7eb !important;  /* gris más fuerte */
-  border: 1px solid #9ca3af !important;  /* borde gris */
-  color: #111827 !important;             /* texto oscuro */
+  background-color: var(--hover-light) !important;  /* gris más fuerte */
+  border: 1px solid var(--border-muted) !important;  /* borde gris */
+  color: var(--text-dark) !important;             /* texto oscuro */
   font-weight: 600;
   border-radius: 8px;
   padding-left: 8px;
@@ -212,7 +211,7 @@
 /* Cuando el usuario hace foco */
 .editar-rutinas select[name^="categoria"]:focus,
 .editar-rutinas select[name^="cal_categoria"]:focus {
-  background-color: #ffffff !important;  /* se diferencia en blanco */
+  background-color: var(--bg-light) !important;  /* se diferencia en blanco */
   border-color: var(--accent) !important;
   box-shadow: 0 0 0 3px var(--accent-focus) !important;
 }
@@ -237,7 +236,7 @@
   border-collapse: separate;
   border-spacing: 0;
   background: rgba(255, 255, 255, 0.04);
-  color: #f8f9fa;
+  color: var(--text-light);
   border: 1px solid rgba(255, 255, 255, 0.15);
   border-radius: 0.75rem;
   overflow: hidden;
@@ -249,7 +248,7 @@
 }
 .rutinas-table thead th {
   background: rgba(255, 255, 255, 0.08);
-  color: #fff;
+  color: var(--text-light);
   font-weight: 600;
 }
 .rutinas-table tbody tr:nth-child(odd) {
@@ -262,14 +261,14 @@
 /* -------- Tabulator custom style -------- */
 #rutinasTable {
   font-family: 'Montserrat', sans-serif;
-  color: #f8f9fa;
+  color: var(--text-light);
 }
 
 .tabulator { background: transparent; }
 
 .tabulator .tabulator-header {
   background: rgba(0, 0, 0, 0.4);
-  color: #f8f9fa;
+  color: var(--text-light);
   border-bottom: 1px solid rgba(255, 255, 255, 0.2);
 }
 
@@ -295,45 +294,45 @@
   background: rgba(37, 99, 235, 0.15);
 }
 .rutinas-table tbody td:focus {
-  outline: 2px solid #2563eb;
+  outline: 2px solid var(--focus-outline);
   outline-offset: -2px;
 }
 
 /* Cabecera de tarjetas para rutinas */
 .rutinas-card-header {
   background: rgba(0, 0, 0, 0.6);
-  color: #f8f9fa;
+  color: var(--text-light);
   font-weight: 600;
 }
 
 /* -------- Tablas genéricas del sitio -------- */
 body:not(.editar-rutinas) .table:not(.rutinas-table) {
-  background-color: #1e1e2a !important;
+  background-color: var(--bg-dark) !important;
   border-collapse: separate;
   border-spacing: 0;
-  color: #ffffff !important;
+  color: var(--text-light) !important;
   font-size: 0.95rem;
 }
 
 body:not(.editar-rutinas) .table-striped:not(.rutinas-table) tbody tr:nth-of-type(odd) {
-  background-color: #2a2a3c !important;
+  background-color: var(--bg-dark-alt) !important;
 }
 
 body:not(.editar-rutinas) .table:not(.rutinas-table) td,
 body:not(.editar-rutinas) .table:not(.rutinas-table) th {
-  color: #ffffff !important;
+  color: var(--text-light) !important;
   font-weight: 600 !important;
   background-color: transparent !important;
-  border-color: #444 !important;
+  border-color: var(--border-dark) !important;
 }
 
 body:not(.editar-rutinas) .table:not(.rutinas-table) thead {
-  background-color: #2d2d45 !important;
+  background-color: var(--bg-dark-alt) !important;
 }
 
 body:not(.editar-rutinas) .table:not(.rutinas-table) thead th {
-  color: #f9f9f9 !important;
+  color: var(--text-light) !important;
   font-weight: 700 !important;
-  border-bottom: 2px solid #555 !important;
+  border-bottom: 2px solid var(--border-dark) !important;
 }
 

--- a/static/css/socios.css
+++ b/static/css/socios.css
@@ -1,7 +1,7 @@
 /* Contenedor general de la lista */
 .container h2 {
     font-weight: 700;
-    color: #2c3e50;
+    color: var(--text-dark);
     margin-bottom: 20px;
 }
 
@@ -9,13 +9,13 @@
 .table {
     border-radius: 12px;
     overflow: hidden;
-    background-color: #fff;
+    background-color: var(--bg-light);
 }
 
 /* Encabezados */
 .table thead th {
-    background: linear-gradient(135deg, #2c3e50, #34495e);
-    color: #f8f9fa !important;
+    background: linear-gradient(135deg, var(--bg-dark), var(--bg-dark-alt));
+    color: var(--text-light) !important;
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.5px;
@@ -26,13 +26,13 @@
     transition: background-color 0.2s ease-in-out;
 }
 .table tbody tr:hover {
-    background-color: #f2f6fc;
+    background-color: var(--hover-light);
 }
 
 /* Texto dentro de la tabla */
 .table td {
     vertical-align: middle;
-    color: #2c3e50;
+    color: var(--text-dark);
 }
 
 /* Badges */
@@ -55,12 +55,12 @@
 
 /* Input búsqueda lista de socios */
 .container form input.form-control {
-    background-color: #2c3e50 !important;  /* fondo gris oscuro */
-    color: #fff !important;               /* texto blanco */
-    border: 1px solid #444 !important;
+    background-color: var(--bg-dark) !important;  /* fondo gris oscuro */
+    color: var(--text-light) !important;               /* texto blanco */
+    border: 1px solid var(--border-dark) !important;
 }
 
 /* Placeholder */
 .container form input.form-control::placeholder {
-    color: #ccc !important;
+    color: var(--placeholder) !important;
 }

--- a/static/js/theme-toggle.js
+++ b/static/js/theme-toggle.js
@@ -1,0 +1,19 @@
+(function() {
+    const toggle = document.getElementById('theme-toggle');
+    if (!toggle) return;
+    const body = document.body;
+    const stored = localStorage.getItem('theme');
+    if (stored === 'light') {
+        body.classList.remove('dark-mode');
+        body.classList.add('light-mode');
+    } else {
+        body.classList.add('dark-mode');
+    }
+    toggle.addEventListener('click', function() {
+        body.classList.toggle('light-mode');
+        body.classList.toggle('dark-mode');
+        const theme = body.classList.contains('light-mode') ? 'light' : 'dark';
+        localStorage.setItem('theme', theme);
+    });
+})();
+


### PR DESCRIPTION
## Summary
- centralize color palette with CSS variables
- refactor member and routine styles to use shared variables
- add light/dark theme toggle with persistent preference

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68ae3504747483239c0757a9be837138