### PR TITLE
Configure settings with environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+DJANGO_SECRET_KEY=your-secret-key
+DJANGO_DEBUG=True

--- a/gym/settings.py
+++ b/gym/settings.py
@@ -3,11 +3,11 @@ from pathlib import Path
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 
-SECRET_KEY = 'django-insecure-1234567890-esto-es-un-ejemplo'
+SECRET_KEY = os.getenv("DJANGO_SECRET_KEY", "django-insecure-1234567890-esto-es-un-ejemplo")
 
-DEBUG = True
+DEBUG = os.getenv("DJANGO_DEBUG", "False").lower() == "true"
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ["localhost", "127.0.0.1"]
 
 INSTALLED_APPS = [
     'django.contrib.admin',


### PR DESCRIPTION
## Summary
- Load secret key and debug from environment variables
- Add default allowed hosts
- Document environment variables in `.env.example`

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68af1bb24d1c8323a0b96222f077df6c