### PR TITLE
Use POST forms for payment toggles

### DIFF
--- a/gymapp/templates/gymapp/historial_pagos.html
+++ b/gymapp/templates/gymapp/historial_pagos.html
@@ -17,10 +17,12 @@
                 <span class="badge bg-danger">Debe</span>
               {% endif %}
             </div>
-            <a href="{% url 'toggle_payment_mes' member.id item.mes %}"
-               class="btn {% if item.pagado %}btn-outline-warning{% else %}btn-outline-success{% endif %} w-100">
-              {% if item.pagado %}Anular pago{% else %}Marcar pagado{% endif %}
-            </a>
+            <form method="post" action="{% url 'toggle_payment_mes' member.id item.mes %}">
+              {% csrf_token %}
+              <button type="submit" class="btn {% if item.pagado %}btn-outline-warning{% else %}btn-outline-success{% endif %} w-100">
+                {% if item.pagado %}Anular pago{% else %}Marcar pagado{% endif %}
+              </button>
+            </form>
           </div>
         </div>
       </div>

--- a/gymapp/templates/gymapp/partials/_member_rows.html
+++ b/gymapp/templates/gymapp/partials/_member_rows.html
@@ -9,9 +9,15 @@
   <td>
     {% if member.id in pagos_ids %}
       <span class="badge bg-success">Pagado</span>
-      <a href="{% url 'toggle_payment' member.id %}" class="btn btn-outline-warning btn-sm ms-2">Anular</a>
+      <form method="post" action="{% url 'toggle_payment' member.id %}" style="display:inline;">
+        {% csrf_token %}
+        <button type="submit" class="btn btn-outline-warning btn-sm ms-2">Anular</button>
+      </form>
     {% else %}
-      <a href="{% url 'toggle_payment' member.id %}" class="btn btn-danger btn-sm">Debe</a>
+      <form method="post" action="{% url 'toggle_payment' member.id %}" style="display:inline;">
+        {% csrf_token %}
+        <button type="submit" class="btn btn-danger btn-sm">Debe</button>
+      </form>
     {% endif %}
   </td>
 

--- a/gymapp/urls.py
+++ b/gymapp/urls.py
@@ -9,9 +9,9 @@ urlpatterns = [
     path('eliminar/<int:pk>/', views.delete_member, name='delete_member'),
 
     # Pagos
-    path('pagar/<int:member_id>/', views.toggle_payment, name='toggle_payment'),
+    path('pagar/<int:member_id>/', views.toggle_payment, name='toggle_payment'),  # POST
     path('historial/<int:member_id>/', views.historial_pagos, name='historial_pagos'),
-    path('toggle_pago/<int:member_id>/<str:mes>/', views.toggle_payment_mes, name='toggle_payment_mes'),
+    path('toggle_pago/<int:member_id>/<str:mes>/', views.toggle_payment_mes, name='toggle_payment_mes'),  # POST
     path('exportar_excel/', views.export_members_excel, name='export_members_excel'),
 
     # Cliente login

--- a/gymapp/views.py
+++ b/gymapp/views.py
@@ -10,6 +10,7 @@ from .forms import MemberForm, MemberInfoForm
 from .models import Member, Payment, Ejercicio, Rutina, DetalleRutina, ComentarioRutina
 
 from django.utils import timezone
+from django.views.decorators.http import require_POST
 
 
 
@@ -69,6 +70,7 @@ def delete_member(request, pk):
 
 # === Pagos ===
 
+@require_POST
 def toggle_payment(request, member_id):
     member = get_object_or_404(Member, pk=member_id)
     mes_actual = date.today().strftime("%m-%Y")
@@ -106,6 +108,7 @@ def historial_pagos(request, member_id):
     })
 
 
+@require_POST
 def toggle_payment_mes(request, member_id, mes):
     member = get_object_or_404(Member, pk=member_id)
     pago = Payment.objects.filter(member=member, mes=mes).first()


### PR DESCRIPTION
## Summary
- Protect payment toggle endpoints with POST-only decorators
- Replace payment toggle links with CSRF-protected forms and submit buttons

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68af1bb9acf483238f22e4cd4788e3fb