### PR TITLE
Refactor editar_rutina with atomic bulk create

### DIFF
--- a/gymapp/forms.py
+++ b/gymapp/forms.py
@@ -1,5 +1,6 @@
 from django import forms
-from .models import Member
+from django.forms import inlineformset_factory
+from .models import Member, Rutina, DetalleRutina
 
 
 
@@ -44,3 +45,23 @@ class MemberInfoForm(forms.ModelForm):
             'enfermedades': forms.Textarea(attrs={'rows': 3}),
             'objetivos': forms.Textarea(attrs={'rows': 3}),
         }
+
+
+DetalleRutinaFormSet = inlineformset_factory(
+    Rutina,
+    DetalleRutina,
+    fields=[
+        "categoria",
+        "ejercicio",
+        "series",
+        "repeticiones",
+        "peso",
+        "descanso",
+        "rir",
+        "sensaciones",
+        "notas",
+        "es_calentamiento",
+    ],
+    extra=0,
+    can_delete=False,
+)


### PR DESCRIPTION
## Summary
- Add inline formset for DetalleRutina to centralize validation
- Use transaction.atomic and bulk_create in editar_rutina view

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68af1b56dabc8323b71d76e331dbc27c