### PR TITLE
Normalize Gmail addresses

### DIFF
--- a/gymapp/forms.py
+++ b/gymapp/forms.py
@@ -21,8 +21,11 @@ class MemberForm(forms.ModelForm):
 
     def clean_gmail(self):
         gmail = self.cleaned_data.get('gmail')
-        if gmail and not gmail.endswith("@gmail.com"):
-            raise forms.ValidationError("El correo debe terminar en @gmail.com")
+        if gmail:
+            gmail = gmail.lower()
+            if not gmail.endswith("@gmail.com"):
+                raise forms.ValidationError("El correo debe terminar en @gmail.com")
+            self.cleaned_data['gmail'] = gmail
         return gmail
 
 


### PR DESCRIPTION
## Summary
- Normalize Gmail addresses in `MemberForm.clean_gmail` by lowercasing input and storing normalized value

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68af1ba0dbb883238abec1b96d78780f