### PR TITLE
Optimize mis_rutinas query with select_related

### DIFF
--- a/gymapp/tests.py
+++ b/gymapp/tests.py
@@ -1,4 +1,6 @@
+from django.db import connection
 from django.test import TestCase
+from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
 
 from .models import Member, Rutina, DetalleRutina, Ejercicio
@@ -37,4 +39,36 @@ class RutinaClienteDuplicationTest(TestCase):
         calentamientos = nueva.detalles.filter(es_calentamiento=True)
         self.assertEqual(calentamientos.count(), 1)
         self.assertEqual(calentamientos.first().repeticiones, "10")
+
+
+class MisRutinasQueryTest(TestCase):
+    def test_select_related_reduces_queries(self):
+        member = Member.objects.create(dni="1", nombre_apellido="Test")
+        ejercicio = Ejercicio.objects.create(nombre="Push Up")
+        rutina = Rutina.objects.create(member=member, estructura="hipertrofia")
+
+        for _ in range(5):
+            DetalleRutina.objects.create(
+                rutina=rutina,
+                categoria="Fuerza",
+                ejercicio=ejercicio,
+                series="3",
+                repeticiones="10",
+            )
+
+        def fetch_with_all():
+            return [d.ejercicio.nombre for d in rutina.detalles.all()]
+
+        def fetch_with_select_related():
+            return [d.ejercicio.nombre for d in rutina.detalles.select_related("ejercicio")]
+
+        with CaptureQueriesContext(connection) as ctx:
+            fetch_with_all()
+        queries_all = len(ctx.captured_queries)
+
+        with CaptureQueriesContext(connection) as ctx:
+            fetch_with_select_related()
+        queries_select = len(ctx.captured_queries)
+
+        self.assertTrue(queries_select < queries_all)
 

--- a/gymapp/views.py
+++ b/gymapp/views.py
@@ -351,7 +351,7 @@ def mis_rutinas(request, member_id):
     rutina_data = {}
     for rutina in rutinas:
         data = list(
-            rutina.detalles.all().values(
+            rutina.detalles.select_related("ejercicio").values(
                 "categoria",
                 "series",
                 "repeticiones",


### PR DESCRIPTION
## Summary
- use `select_related('ejercicio')` when collecting routine details in `mis_rutinas`
- add test ensuring select_related reduces database queries

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68af1bd546d08323a74f63ec3a861f8b