### PR TITLE
Improve form accessibility and error display

### DIFF
--- a/gymapp/forms.py
+++ b/gymapp/forms.py
@@ -19,6 +19,9 @@ class MemberForm(forms.ModelForm):
             'objetivos': forms.Textarea(attrs={'rows': 3}),
         }
 
+
+
+
     def clean_gmail(self):
         gmail = self.cleaned_data.get('gmail')
         if gmail and not gmail.endswith("@gmail.com"):

--- a/gymapp/templates/gymapp/add_member.html
+++ b/gymapp/templates/gymapp/add_member.html
@@ -7,62 +7,69 @@
 <h2 class="mb-4 text-center title-spaced">Agregar nuevo socio</h2>
 <form autocomplete="off" method="post">
             {% csrf_token %}
-            
+
 <div class="mb-3">
 <label class="form-label" for="id_dni">DNI</label>
-{{ form.dni|add_class:"form-control" }}
+{{ form.dni|add_class:"form-control"|attr:"autocomplete:off" }}
+{% for error in form.dni.errors %}<div class="text-danger small">{{ error }}</div>{% endfor %}
 </div>
 
 <div class="mb-3">
 <label class="form-label" for="id_nombre_apellido">Nombre y apellido</label>
-                {{ form.nombre_apellido|add_class:"form-control" }}
-            </div>
+                {{ form.nombre_apellido|add_class:"form-control"|attr:"autocomplete:name" }}
+            {% for error in form.nombre_apellido.errors %}<div class="text-danger small">{{ error }}</div>{% endfor %}</div>
 <div class="mb-3">
 <label class="form-label" for="id_telefono">Teléfono</label>
-                {{ form.telefono|add_class:"form-control" }}
-            </div>
+                {{ form.telefono|add_class:"form-control"|attr:"autocomplete:tel" }}
+            {% for error in form.telefono.errors %}<div class="text-danger small">{{ error }}</div>{% endfor %}</div>
 <div class="mb-3">
 <label class="form-label" for="id_direccion">Dirección</label>
-                {{ form.direccion|add_class:"form-control" }}
-            </div>
+                {{ form.direccion|add_class:"form-control"|attr:"autocomplete:street-address" }}
+            {% for error in form.direccion.errors %}<div class="text-danger small">{{ error }}</div>{% endfor %}</div>
 <div class="mb-3">
 <label class="form-label" for="id_gmail">Gmail</label>
-                {{ form.gmail|add_class:"form-control" }}
+                {{ form.gmail|add_class:"form-control"|attr:"autocomplete:email" }}
             {% for error in form.gmail.errors %}<div class="text-danger small">{{ error }}</div>{% endfor %}</div>
 <div class="mb-3">
 <label class="form-label" for="id_edad">Edad</label>
-                {{ form.edad|add_class:"form-control" }}
-            </div>
+                {{ form.edad|add_class:"form-control"|attr:"autocomplete:off" }}
+            {% for error in form.edad.errors %}<div class="text-danger small">{{ error }}</div>{% endfor %}</div>
 <hr/>
 <div class="mb-3">
 <label class="form-label" for="id_historial_deportivo">Historial deportivo</label>
-                {{ form.historial_deportivo|add_class:"form-control" }}
+                {{ form.historial_deportivo|add_class:"form-control"|attr:"autocomplete:off" }}
                 <div class="form-text">¿Hizo deportes antes? ¿Cuáles?</div>
+            {% for error in form.historial_deportivo.errors %}<div class="text-danger small">{{ error }}</div>{% endfor %}
 </div>
 <div class="mb-3">
 <label class="form-label" for="id_experiencias_gimnasios">Experiencias en gimnasios</label>
-                {{ form.experiencias_gimnasios|add_class:"form-control" }}
+                {{ form.experiencias_gimnasios|add_class:"form-control"|attr:"autocomplete:off" }}
                 <div class="form-text">¿Ya entrenó en gimnasios?</div>
+            {% for error in form.experiencias_gimnasios.errors %}<div class="text-danger small">{{ error }}</div>{% endfor %}
 </div>
 <div class="mb-3">
 <label class="form-label" for="id_historial_lesivo">Historial lesivo</label>
-                {{ form.historial_lesivo|add_class:"form-control" }}
+                {{ form.historial_lesivo|add_class:"form-control"|attr:"autocomplete:off" }}
                 <div class="form-text">Lesiones previas, operaciones, etc.</div>
+            {% for error in form.historial_lesivo.errors %}<div class="text-danger small">{{ error }}</div>{% endfor %}
 </div>
 <div class="mb-3">
 <label class="form-label" for="id_enfermedades">Enfermedades</label>
-                {{ form.enfermedades|add_class:"form-control" }}
+                {{ form.enfermedades|add_class:"form-control"|attr:"autocomplete:off" }}
                 <div class="form-text">¿Alguna enfermedad relevante?</div>
+            {% for error in form.enfermedades.errors %}<div class="text-danger small">{{ error }}</div>{% endfor %}
 </div>
 <div class="mb-3">
 <label class="form-label" for="id_objetivos">Objetivos</label>
-                {{ form.objetivos|add_class:"form-control" }}
+                {{ form.objetivos|add_class:"form-control"|attr:"autocomplete:off" }}
                 <div class="form-text">¿Qué busca lograr en el gimnasio?</div>
+            {% for error in form.objetivos.errors %}<div class="text-danger small">{{ error }}</div>{% endfor %}
 </div>
 <div class="mb-3">
 <label class="form-label" for="id_frecuencia_semana">Frecuencia por semana</label>
-                {{ form.frecuencia_semana|add_class:"form-control" }}
+                {{ form.frecuencia_semana|add_class:"form-control"|attr:"autocomplete:off" }}
                 <div class="form-text">¿Cuántos días por semana piensa venir?</div>
+            {% for error in form.frecuencia_semana.errors %}<div class="text-danger small">{{ error }}</div>{% endfor %}
 </div>
 <div class="d-flex justify-content-between mt-4">
 <button class="btn btn-success btn-lg px-4 rounded-4" type="submit">Agregar</button>

--- a/gymapp/templates/gymapp/edit_member.html
+++ b/gymapp/templates/gymapp/edit_member.html
@@ -1,13 +1,76 @@
 {% extends 'gymapp/base.html' %}
+{% load widget_tweaks %}
 {% block title %}Editar Socio{% endblock %}
 {% block content %}
-{% load widget_tweaks %}
 <div class="card shadow rounded p-4 mx-auto card-600">
-<h2 class="mb-4">Editar socio</h2>
-<form method="post">
-    {% csrf_token %}<button class="btn btn-primary" type="submit">Guardar cambios</button>
-<div class="mb-3"><label class="form-label" for="id_dni">DNI</label>{{ form.dni|add_class:"form-control" }}</div>
-<div class="mb-3"><label class="form-label" for="id_nombre_apellido">Nombre apellido</label>{{ form.nombre_apellido|add_class:"form-control" }}{% for error in form.nombre_apellido.errors %}<div class="text-danger small">{{ error }}</div>{% endfor %}</div><div class="mb-3"><label class="form-label" for="id_telefono">Telefono</label>{{ form.telefono|add_class:"form-control" }}{% for error in form.telefono.errors %}<div class="text-danger small">{{ error }}</div>{% endfor %}</div><div class="mb-3"><label class="form-label" for="id_direccion">Direccion</label>{{ form.direccion|add_class:"form-control" }}{% for error in form.direccion.errors %}<div class="text-danger small">{{ error }}</div>{% endfor %}</div><div class="mb-3"><label class="form-label" for="id_gmail">Gmail</label>{{ form.gmail|add_class:"form-control" }}{% for error in form.gmail.errors %}{% endfor %}{% for error in form.gmail.errors %}<div class="text-danger small">{{ error }}</div>{% endfor %}</div><div class="mb-3"><label class="form-label" for="id_edad">Edad</label>{{ form.edad|add_class:"form-control" }}{% for error in form.edad.errors %}<div class="text-danger small">{{ error }}</div>{% endfor %}</div><div class="mb-3"><label class="form-label" for="id_historial_deportivo">Historial deportivo</label>{{ form.historial_deportivo|add_class:"form-control" }}{% for error in form.historial_deportivo.errors %}<div class="text-danger small">{{ error }}</div>{% endfor %}</div><div class="mb-3"><label class="form-label" for="id_experiencias_gimnasios">Experiencias gimnasios</label>{{ form.experiencias_gimnasios|add_class:"form-control" }}{% for error in form.experiencias_gimnasios.errors %}<div class="text-danger small">{{ error }}</div>{% endfor %}</div><div class="mb-3"><label class="form-label" for="id_historial_lesivo">Historial lesivo</label>{{ form.historial_lesivo|add_class:"form-control" }}{% for error in form.historial_lesivo.errors %}<div class="text-danger small">{{ error }}</div>{% endfor %}</div><div class="mb-3"><label class="form-label" for="id_enfermedades">Enfermedades</label>{{ form.enfermedades|add_class:"form-control" }}{% for error in form.enfermedades.errors %}<div class="text-danger small">{{ error }}</div>{% endfor %}</div><div class="mb-3"><label class="form-label" for="id_objetivos">Objetivos</label>{{ form.objetivos|add_class:"form-control" }}{% for error in form.objetivos.errors %}<div class="text-danger small">{{ error }}</div>{% endfor %}</div><div class="mb-3"><label class="form-label" for="id_frecuencia_semana">Frecuencia semana</label>{{ form.frecuencia_semana|add_class:"form-control" }}{% for error in form.frecuencia_semana.errors %}<div class="text-danger small">{{ error }}</div>{% endfor %}</div><a class="btn btn-secondary" href="{% url 'member_list' %}">Volver</a>
-</form>
+  <h2 class="mb-4">Editar socio</h2>
+  <form method="post" autocomplete="off">
+    {% csrf_token %}
+    <div class="mb-3">
+      <label class="form-label" for="id_dni">DNI</label>
+      {{ form.dni|add_class:"form-control"|attr:"autocomplete:off" }}
+      {% for error in form.dni.errors %}<div class="text-danger small">{{ error }}</div>{% endfor %}
+    </div>
+    <div class="mb-3">
+      <label class="form-label" for="id_nombre_apellido">Nombre apellido</label>
+      {{ form.nombre_apellido|add_class:"form-control"|attr:"autocomplete:name" }}
+      {% for error in form.nombre_apellido.errors %}<div class="text-danger small">{{ error }}</div>{% endfor %}
+    </div>
+    <div class="mb-3">
+      <label class="form-label" for="id_telefono">Telefono</label>
+      {{ form.telefono|add_class:"form-control"|attr:"autocomplete:tel" }}
+      {% for error in form.telefono.errors %}<div class="text-danger small">{{ error }}</div>{% endfor %}
+    </div>
+    <div class="mb-3">
+      <label class="form-label" for="id_direccion">Direccion</label>
+      {{ form.direccion|add_class:"form-control"|attr:"autocomplete:street-address" }}
+      {% for error in form.direccion.errors %}<div class="text-danger small">{{ error }}</div>{% endfor %}
+    </div>
+    <div class="mb-3">
+      <label class="form-label" for="id_gmail">Gmail</label>
+      {{ form.gmail|add_class:"form-control"|attr:"autocomplete:email" }}
+      {% for error in form.gmail.errors %}<div class="text-danger small">{{ error }}</div>{% endfor %}
+    </div>
+    <div class="mb-3">
+      <label class="form-label" for="id_edad">Edad</label>
+      {{ form.edad|add_class:"form-control"|attr:"autocomplete:off" }}
+      {% for error in form.edad.errors %}<div class="text-danger small">{{ error }}</div>{% endfor %}
+    </div>
+    <div class="mb-3">
+      <label class="form-label" for="id_historial_deportivo">Historial deportivo</label>
+      {{ form.historial_deportivo|add_class:"form-control"|attr:"autocomplete:off" }}
+      {% for error in form.historial_deportivo.errors %}<div class="text-danger small">{{ error }}</div>{% endfor %}
+    </div>
+    <div class="mb-3">
+      <label class="form-label" for="id_experiencias_gimnasios">Experiencias gimnasios</label>
+      {{ form.experiencias_gimnasios|add_class:"form-control"|attr:"autocomplete:off" }}
+      {% for error in form.experiencias_gimnasios.errors %}<div class="text-danger small">{{ error }}</div>{% endfor %}
+    </div>
+    <div class="mb-3">
+      <label class="form-label" for="id_historial_lesivo">Historial lesivo</label>
+      {{ form.historial_lesivo|add_class:"form-control"|attr:"autocomplete:off" }}
+      {% for error in form.historial_lesivo.errors %}<div class="text-danger small">{{ error }}</div>{% endfor %}
+    </div>
+    <div class="mb-3">
+      <label class="form-label" for="id_enfermedades">Enfermedades</label>
+      {{ form.enfermedades|add_class:"form-control"|attr:"autocomplete:off" }}
+      {% for error in form.enfermedades.errors %}<div class="text-danger small">{{ error }}</div>{% endfor %}
+    </div>
+    <div class="mb-3">
+      <label class="form-label" for="id_objetivos">Objetivos</label>
+      {{ form.objetivos|add_class:"form-control"|attr:"autocomplete:off" }}
+      {% for error in form.objetivos.errors %}<div class="text-danger small">{{ error }}</div>{% endfor %}
+    </div>
+    <div class="mb-3">
+      <label class="form-label" for="id_frecuencia_semana">Frecuencia semana</label>
+      {{ form.frecuencia_semana|add_class:"form-control"|attr:"autocomplete:off" }}
+      {% for error in form.frecuencia_semana.errors %}<div class="text-danger small">{{ error }}</div>{% endfor %}
+    </div>
+    <div class="d-flex gap-2">
+      <button class="btn btn-primary" type="submit">Guardar cambios</button>
+      <a class="btn btn-secondary" href="{% url 'member_list' %}">Volver</a>
+    </div>
+  </form>
 </div>
 {% endblock %}
+

--- a/gymapp/templates/gymapp/editar_rutina.html
+++ b/gymapp/templates/gymapp/editar_rutina.html
@@ -54,10 +54,10 @@
                     {% endfor %}
                   </select>
                 </div>
-                <div class="repeticiones"><input type="text" class="form-control" name="cal_repeticiones_0" placeholder="Ej: 2x15 o tiempo"></div>
-                <div class="notas"><input type="text" class="form-control" name="cal_notas_0" placeholder="Notas"></div>
+                <div class="repeticiones"><input type="text" class="form-control" name="cal_repeticiones_0" placeholder="Ej: 2x15 o tiempo" autocomplete="off"></div>
+                <div class="notas"><input type="text" class="form-control" name="cal_notas_0" placeholder="Notas" autocomplete="off"></div>
                 <div class="acciones text-center">
-                  <button type="button" class="btn btn-danger btn-sm" onclick="eliminarFila(this,'tablaCalentamiento')">
+                  <button type="button" class="btn btn-danger btn-sm" onclick="eliminarFila(this,'tablaCalentamiento')" aria-label="Eliminar fila">
                     <i class="bi bi-x-lg"></i>
                   </button>
                 </div>
@@ -119,19 +119,19 @@
                       {% endfor %}
                     </select>
                   </div>
-                  <div class="notas"><input type="text" class="form-control" name="notas_0" placeholder="Notas"></div>
-                  <div class="series"><input type="text" class="form-control" name="series_0" placeholder="Ej: 4"></div>
-                  <div class="repeticiones"><input type="text" class="form-control" name="repeticiones_0" placeholder="Ej: 10-12"></div>
-                  <div class="kilos"><input type="text" class="form-control" name="peso_0" placeholder="Ej: 30"></div>
+                  <div class="notas"><input type="text" class="form-control" name="notas_0" placeholder="Notas" autocomplete="off"></div>
+                  <div class="series"><input type="text" class="form-control" name="series_0" placeholder="Ej: 4" autocomplete="off"></div>
+                  <div class="repeticiones"><input type="text" class="form-control" name="repeticiones_0" placeholder="Ej: 10-12" autocomplete="off"></div>
+                  <div class="kilos"><input type="text" class="form-control" name="peso_0" placeholder="Ej: 30" autocomplete="off"></div>
                   <div class="rir">
                     <select name="rir_0" class="form-select">
                       <option value="">-</option>
                       <option>0</option><option>1</option><option>2</option><option>3</option><option>4</option>
                     </select>
                   </div>
-                  <div class="sensaciones"><input type="text" class="form-control" name="sensaciones_0" placeholder="Cómo lo sentiste"></div>
+                  <div class="sensaciones"><input type="text" class="form-control" name="sensaciones_0" placeholder="Cómo lo sentiste" autocomplete="off"></div>
                   <div class="acciones text-center">
-                    <button type="button" class="btn btn-danger btn-sm" onclick="eliminarFila(this,'tablaRutina')">
+                    <button type="button" class="btn btn-danger btn-sm" onclick="eliminarFila(this,'tablaRutina')" aria-label="Eliminar fila">
                       <i class="bi bi-x-lg"></i>
                     </button>
                   </div>

--- a/gymapp/templates/gymapp/login_cliente.html
+++ b/gymapp/templates/gymapp/login_cliente.html
@@ -8,7 +8,7 @@
       {% csrf_token %}
       <div class="mb-3">
         <label for="dni" class="form-label">DNI</label>
-        <input id="dni" name="dni" type="text" class="form-control" placeholder="Ej: 40123456">
+        <input id="dni" name="dni" type="text" class="form-control" placeholder="Ej: 40123456" autocomplete="off">
       </div>
       <button class="btn btn-success w-100">Ingresar</button>
     </form>

--- a/gymapp/templates/gymapp/member_list.html
+++ b/gymapp/templates/gymapp/member_list.html
@@ -9,7 +9,7 @@
 
     <!-- Barra de búsqueda -->
     <form method="get" class="mb-3">
-        <input type="text" name="q" value="{{ request.GET.q }}" class="form-control search-member" placeholder="Buscar socio...">
+        <input type="text" name="q" value="{{ request.GET.q }}" class="form-control search-member" placeholder="Buscar socio..." autocomplete="off">
     </form>
 
     <div class="table-responsive">
@@ -31,13 +31,13 @@
                         <td>{{ member.telefono }}</td>
                         <td>{{ member.gmail }}</td>
                         <td>
-                            <a href="{% url 'edit_member' member.id %}" class="btn btn-sm btn-primary">
+                            <a href="{% url 'edit_member' member.id %}" class="btn btn-sm btn-primary" aria-label="Editar">
                                 <i class="bi bi-pencil"></i>
                             </a>
-                            <a href="{% url 'delete_member' member.id %}" class="btn btn-sm btn-danger">
+                            <a href="{% url 'delete_member' member.id %}" class="btn btn-sm btn-danger" aria-label="Eliminar">
                                 <i class="bi bi-trash"></i>
                             </a>
-                            <a href="{% url 'historial_pagos' member.id %}" class="btn btn-sm btn-warning">
+                            <a href="{% url 'historial_pagos' member.id %}" class="btn btn-sm btn-warning" aria-label="Historial de pagos">
                                 <i class="bi bi-cash-coin"></i>
                             </a>
                             <a href="{% url 'rutina_cliente' member.id %}" class="btn btn-sm btn-success">


### PR DESCRIPTION
## Summary
- add autocomplete hints and inline error messages to member forms
- include aria-labels for icon buttons and disable unwanted autocomplete
- prevent browser autofill in routine editor inputs

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68af1bdef2088323af0c64375014616f