### PR TITLE
Add monthly payment summary view

### DIFF
--- a/gymapp/templates/gymapp/base.html
+++ b/gymapp/templates/gymapp/base.html
@@ -48,6 +48,10 @@
                   <i class="bi bi-file-earmark-excel-fill fs-5"></i>
                   Exportar Excel
               </a>
+              <a href="{% url 'resumen_mensual' %}" class="btn btn-outline-light btn-lg fw-semibold rounded-pill ms-2 d-flex align-items-center gap-1 shadow-sm">
+                  <i class="bi bi-graph-up fs-5"></i>
+                  Resumen mensual
+              </a>
           </div>
       </div>
   </nav>

--- a/gymapp/urls.py
+++ b/gymapp/urls.py
@@ -14,6 +14,7 @@ urlpatterns = [
     path('toggle_pago/<int:member_id>/<str:mes>/', views.toggle_payment_mes, name='toggle_payment_mes'),  # POST
     path('exportar_excel/', views.export_members_excel, name='export_members_excel'),
     path('eliminar_pago/<int:pago_id>/', views.eliminar_pago, name='eliminar_pago'),
+    path('resumen_mensual/', views.resumen_mensual, name='resumen_mensual'),
 
 
     # Cliente login

--- a/gymapp/views.py
+++ b/gymapp/views.py
@@ -1,4 +1,5 @@
 from datetime import date, datetime
+from decimal import Decimal
 import json
 import openpyxl
 from django.db.models import Q, F, Sum, Count
@@ -183,6 +184,56 @@ def toggle_payment_mes(request, member_id, mes):
         pago.pagado = not pago.pagado
         pago.save(update_fields=["pagado"])
     return redirect('historial_pagos', member_id=member_id)
+
+
+def resumen_mensual(request):
+    """Muestra el resumen de pagos de un mes determinado."""
+
+    mes_param = (request.GET.get("mes") or "").strip()
+    hoy = timezone.localdate()
+
+    try:
+        mes = datetime.strptime(mes_param, "%Y-%m").date().replace(day=1) if mes_param else hoy.replace(day=1)
+    except ValueError:
+        mes = hoy.replace(day=1)
+
+    pagos_mes = Payment.objects.select_related("member").filter(mes=mes)
+
+    pagos_plan = (
+        pagos_mes
+        .filter(plan__isnull=False, pagado=True, anulado=False)
+        .values("plan")
+        .annotate(cantidad=Count("id"), subtotal=Sum("monto"))
+    )
+
+    plan_labels = dict(Payment.PLAN_CHOICES)
+    datos = []
+    for item in pagos_plan:
+        plan = item["plan"]
+        datos.append({
+            "plan": plan,
+            "nombre": plan_labels.get(plan, plan),
+            "cantidad": item["cantidad"],
+            "subtotal": item["subtotal"],
+        })
+
+    total_general = Decimal("0")
+    for item in datos:
+        total_general += item["subtotal"] or Decimal("0")
+
+    pagos_list = (
+        pagos_mes
+        .filter(plan__isnull=False, anulado=False)
+        .order_by("member__nombre_apellido", "id")
+    )
+
+    context = {
+        "mes": mes,
+        "datos": datos,
+        "total_general": total_general,
+        "pagos_list": pagos_list,
+    }
+    return render(request, "gymapp/resumen_mensual.html", context)
 
 
 def export_members_excel(request):


### PR DESCRIPTION
## Summary
- add a monthly resumen view that aggregates payments with member data
- expose the summary through the Django URL configuration and navbar link
- cover the new view with focused tests validating totals and filtering

## Testing
- python manage.py test gymapp.tests.ResumenMensualViewTest

------
https://chatgpt.com/codex/tasks/task_e_68df44b201848323a303d641fd97bdec