### PR TITLE
Restringir acceso a mis rutinas por sesión de cliente

### DIFF
--- a/gymapp/templates/gymapp/mis_rutinas.html
+++ b/gymapp/templates/gymapp/mis_rutinas.html
@@ -5,8 +5,8 @@
 <link href="https://unpkg.com/tabulator-tables@5.6.2/dist/css/tabulator.min.css" rel="stylesheet"{% if CDN_INTEGRITY.tabulator_css %} integrity="{{ CDN_INTEGRITY.tabulator_css }}" crossorigin="anonymous"{% endif %}>
 <script src="https://unpkg.com/tabulator-tables@5.6.2/dist/js/tabulator.min.js"{% if CDN_INTEGRITY.tabulator_js %} integrity="{{ CDN_INTEGRITY.tabulator_js }}" crossorigin="anonymous"{% endif %}></script>
 {% else %}
-<link href="{% static 'vendor/tabulator/tabulator.min.css' %}" rel="stylesheet">
-<script src="{% static 'vendor/tabulator/tabulator.min.js' %}"></script>
+<link href="{{ tabulator_css_url }}" rel="stylesheet">
+<script src="{{ tabulator_js_url }}"></script>
 {% endif %}
 {% endblock %}
 

--- a/gymapp/urls.py
+++ b/gymapp/urls.py
@@ -18,6 +18,7 @@ urlpatterns = [
 
     # Cliente login
     path('login_cliente/', views.login_cliente, name='login_cliente'),
+    path('logout_cliente/', views.logout_cliente, name='logout_cliente'),
 
     # Partial para recarga con AJAX
     path('member_rows_partial/', views.member_rows_partial, name='member_rows_partial'),


### PR DESCRIPTION
## Summary
- validación de sesión en la vista mis_rutinas y nuevo logout_cliente para cerrar sesión
- exponer rutas de Tabulator mediante contexto para evitar uso directo de la etiqueta static
- añadir pruebas para cobertura de logout y restricciones de acceso de clientes

## Testing
- python manage.py test

------
https://chatgpt.com/codex/tasks/task_e_68df44c7d91c832388e465579ff1cb41