### PR TITLE
Add extra head block to base template

### DIFF
--- a/gymapp/templates/gymapp/base.html
+++ b/gymapp/templates/gymapp/base.html
@@ -22,6 +22,8 @@
   <link rel="stylesheet" href="{% static 'css/rutinas.css' %}">
   <link rel="stylesheet" href="{% static 'css/forms.css' %}">
 
+  {% block extra_head %}{% endblock %}
+
 
 </head>
 


### PR DESCRIPTION
## Summary
- add an `extra_head` block to the base template head so child templates can include additional assets

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df44cc949c8323a085cffaab1643e8