### PR TITLE
Fix unpaid member payment status display

### DIFF
--- a/gymapp/tests.py
+++ b/gymapp/tests.py
@@ -57,6 +57,24 @@ class MemberListViewTest(TestCase):
         self.assertContains(response, member.nombre_apellido)
 
 
+class MemberRowsPartialViewTest(TestCase):
+    def test_unpaid_payment_shows_debe_badge(self):
+        member = Member.objects.create(dni="2", nombre_apellido="Tester 2")
+        Payment.objects.create(
+            member=member,
+            mes=date.today(),
+            pagado=False,
+        )
+
+        response = self.client.get(reverse("member_rows_partial"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertInHTML(
+            '<span class="badge bg-danger">Debe</span>',
+            response.content.decode(),
+        )
+
+
 class TogglePaymentViewTest(TestCase):
     def test_toggle_payment_creates_and_toggles(self):
         member = Member.objects.create(dni="1", nombre_apellido="Tester")

--- a/gymapp/views.py
+++ b/gymapp/views.py
@@ -247,7 +247,11 @@ def member_rows_partial(request):
 
     current_month = date.today().replace(day=1)
     pagos_ids = set(
-        p.member_id for p in Payment.objects.filter(anulado=False, mes=current_month)
+        p.member_id for p in Payment.objects.filter(
+            anulado=False,
+            pagado=True,
+            mes=current_month,
+        )
     )
 
     return render(request, "gymapp/partials/_member_rows.html", {


### PR DESCRIPTION
## Summary
- ensure the quick payment lookup for the members table only marks members as paid when the monthly payment is both not annulled and marked as paid
- add a regression test that verifies the members partial renders the "Debe" badge when the current month's payment is present but flagged as unpaid

## Testing
- python manage.py test *(fails: existing tests depend on GET access to POST-only views and template tags not loaded in mis_rutinas)*

------
https://chatgpt.com/codex/tasks/task_e_68df44f36f3c8323ba49f45ac2175fab