### PR TITLE
Usar nombre completo en confirmación de baja de socio

### DIFF
--- a/gymapp/templates/gymapp/confirm_delete.html
+++ b/gymapp/templates/gymapp/confirm_delete.html
@@ -2,7 +2,7 @@
 {% block title %}Eliminar Socio{% endblock %}
 {% block content %}
 <div class="card shadow rounded p-4 mx-auto card-600">
-    <h3>¿Seguro que querés eliminar a <span class="text-danger">{{ member.nombre }} {{ member.apellido }}</span>?</h3>
+    <h3>¿Seguro que querés eliminar a <span class="text-danger">{{ member.nombre_apellido }}</span>?</h3>
     <form method="post" class="mt-3">
         {% csrf_token %}
         <button type="submit" class="btn btn-danger">Sí, eliminar</button>


### PR DESCRIPTION
## Summary
- actualizar la plantilla de confirmación de baja para mostrar el campo `nombre_apellido` del socio

## Testing
- python manage.py test

------
https://chatgpt.com/codex/tasks/task_e_68df4502867c8323b78d7bce72e88f1b