### PR TITLE
Preserve rutina semana when duplicating

### DIFF
--- a/gymapp/tests.py
+++ b/gymapp/tests.py
@@ -49,6 +49,19 @@ class RutinaClienteDuplicationTest(TestCase):
         self.assertEqual(calentamientos.first().repeticiones, "10")
 
 
+    def test_duplica_preserva_semana(self):
+        """La duplicación de rutinas mantiene el número de semana"""
+
+        member = Member.objects.create(dni="2", nombre_apellido="Tester")
+        Rutina.objects.create(member=member, estructura="hipertrofia", semana=4)
+
+        self.client.post(reverse("rutina_cliente", args=[member.id]))
+
+        self.assertEqual(member.rutinas.count(), 2)
+        nueva = member.rutinas.order_by("-fecha_creacion").first()
+        self.assertEqual(nueva.semana, 4)
+
+
 class MemberListViewTest(TestCase):
     def test_member_list_displays_members(self):
         member = Member.objects.create(dni="1", nombre_apellido="Tester")

--- a/gymapp/views.py
+++ b/gymapp/views.py
@@ -275,7 +275,11 @@ def rutina_cliente(request, member_id):
     if request.method == "POST":
         ultima = rutinas.first()
         if ultima:
-            nueva = Rutina.objects.create(member=member, estructura=ultima.estructura)
+            nueva = Rutina.objects.create(
+                member=member,
+                estructura=ultima.estructura,
+                semana=ultima.semana,
+            )
             detalles = ultima.detalles.select_related("ejercicio").values(
                 "categoria", "ejercicio_id", "series", "repeticiones", "peso",
                 "descanso", "rir", "sensaciones", "notas", "es_calentamiento",


### PR DESCRIPTION
## Summary
- ensure rutina duplication keeps the original semana value when creating a new record
- cover duplication flow with a regression test that verifies the semana is preserved

## Testing
- python manage.py test gymapp.tests.RutinaClienteDuplicationTest

------
https://chatgpt.com/codex/tasks/task_e_68df454eb2048323a20895d93327e52b